### PR TITLE
Return streams from __getitem__

### DIFF
--- a/regenerator/stream.py
+++ b/regenerator/stream.py
@@ -228,16 +228,16 @@ class Stream:
         return self.chain(other)
 
     def __getitem__(self, idx):
-        '''Index or slice into the stream.  If `idx` is a slice, then a list containing
-        the sliced elements is returned.  If `idx` is an integer, then the sole element
-        located at the provided index will be returned.  Note that these operations may
-        be slow since all elements in the stream must be iterated over until the desired
-        items are found.  Negative indexing is not supported.  If want to create a stream
-        over a slice, instead of a list, consider using the `slice` method instead.
+        '''Index or slice into the stream.  If `idx` is a slice, then a new stream
+        containing the sliced elements is returned, equivalent to the `.slice` method.
+        If `idx` is an integer, then the sole element located at the provided index will
+        be returned.  Note that these operations may be slow since all preceding elements
+        in the stream must be iterated over until the desired items are found.  Negative
+        indexing is not supported.
         '''
         # pylint: disable=unexpected-special-method-signature
         if isinstance(idx, slice):
-            return list(self.slice(idx.start, idx.stop, idx.step))
+            return self.slice(idx.start, idx.stop, idx.step)
 
         if not isinstance(idx, int):
             raise TypeError('indices must be integers or slices, not {}'.format(type(idx).__name__))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,13 +63,11 @@ class CustomStream(regenerator.Stream):
     def __init__(self, n=24):
         super().__init__(lambda: iter(range(n)))
 
-    @regenerator.newstream
-    def even(cls, self):
-        return cls.from_func(lambda: (item for item in self if item % 2 == 0))
+    def even(self):
+        return self.from_func(lambda: (item for item in self if item % 2 == 0))
 
-    @regenerator.newstream
-    def increment(cls, self):
-        return cls.from_func(lambda: (item + 1 for item in self))
+    def increment(self):
+        return self.from_func(lambda: (item + 1 for item in self))
 
 @pytest.fixture
 def custom_stream():

--- a/tests/test_getitem.py
+++ b/tests/test_getitem.py
@@ -23,15 +23,15 @@ def test_idx_out_of_range(list_stream):
 def test_slice(list_stream):
     slice_list = list_stream[2:4]
 
-    assert isinstance(slice_list, list)
+    assert isinstance(slice_list, Stream)
     assert len(slice_list) == 2
 
 def test_empty(empty_stream):
     with pytest.raises(IndexError):
         empty_stream[0]
 
-def test_custom_type(custom_stream):
+def test_custom_type(custom_stream, custom_stream_class):
     slice_list = custom_stream[:10]
 
-    assert isinstance(slice_list, list)
+    assert isinstance(slice_list, custom_stream_class)
     assert len(slice_list) == 10


### PR DESCRIPTION
When using regenerator on some initial projects, it feels very counterintuitive to me that slicing with `[`, e.g., `__getitem__` returns lists instead of streams.  This PR changes that.  The can always get a list with the `list` function if they desire.

Also, this PR eliminates the `newstream` decorator.  Now that stream construction is split with `from_func` and `_init`, this isn't really necessary any longer.